### PR TITLE
Parse connection string `IgnoreWhenParsing` validation

### DIFF
--- a/src/Gemstone.Configuration/ConnectionStringParser.cs
+++ b/src/Gemstone.Configuration/ConnectionStringParser.cs
@@ -317,13 +317,6 @@ public class ConnectionStringParser
 
             if (key is not null)
             {
-                // JRC: Manually ignoring "InputMeasurementKeys" and "OutputMeasurements" properties for now since
-                // these currently cannot be handled through `ConvertToPropertyType` method and will simply throw
-                // an exception, be caught and set to skip. This try/catch in combination with reflection is very
-                // expensive in adapter load chain where many thousands of adapters will all have these properties:
-                if (key.Equals("InputMeasurementKeys", StringComparison.OrdinalIgnoreCase) || key.Equals("OutputMeasurements", StringComparison.OrdinalIgnoreCase))
-                    continue;
-
                 try
                 {
                     property.PropertyInfo.SetValue(settingsObject, ConvertToPropertyType(value, property));

--- a/src/Gemstone.Configuration/ConnectionStringParser.cs
+++ b/src/Gemstone.Configuration/ConnectionStringParser.cs
@@ -113,7 +113,7 @@ public class ConnectionStringParser
 
             if (Required)
             {
-                DefaultValue = null!;
+                DefaultValue = null;
             }
             else
             {

--- a/src/Gemstone.Configuration/ConnectionStringParser.cs
+++ b/src/Gemstone.Configuration/ConnectionStringParser.cs
@@ -37,6 +37,7 @@ using Gemstone.Expressions.Evaluator;
 using Gemstone.Expressions.Model;
 using Gemstone.Reflection.MemberInfoExtensions;
 using Gemstone.StringExtensions;
+using Microsoft.Extensions.Logging;
 
 namespace Gemstone.Configuration;
 
@@ -290,7 +291,7 @@ public class ConnectionStringParser
     /// <exception cref="ArgumentException">A required connection string parameter cannot be found in the connection string.</exception>
     public virtual void ParseConnectionString(string connectionString, object settingsObject)
     {
-        string value;
+        string? value;
 
         // Null objects don't have properties
         if (settingsObject is null)
@@ -306,7 +307,7 @@ public class ConnectionStringParser
         // Parse the connection string into a dictionary of key-value pairs for easy lookups
         Dictionary<string, string> settings = connectionString.ParseKeyValuePairs(ParameterDelimiter, KeyValueDelimiter, StartValueDelimiter, EndValueDelimiter);
 
-        // until we figure out how to parse InputMesurementKeys and OutputMeasurementKeys properly, skip anything that can't be deserialized
+        // until we figure out how to parse InputMeasurementKeys and OutputMeasurementKeys properly, skip anything that can't be deserialized
         // this is very temporary
 
         foreach (ConnectionStringProperty property in connectionStringProperties)
@@ -316,24 +317,45 @@ public class ConnectionStringParser
             bool skip = false;
 
             if (key is not null)
+            {
+                // JRC: Manually ignoring 'InputMeasurementKeys' and 'OutputMeasurements' properties for now since
+                // these are currently cannot be handled through `ConvertToPropertyType` method and will simply throw
+                // and exception, be caught and set to skip. This try/catch in combination with reflection is very
+                // expensive in adapter load chain where many thousands of adapters will all have these properties:
+                if (key.Equals("InputMeasurementKeys", StringComparison.OrdinalIgnoreCase) || key.Equals("OutputMeasurements", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 try
                 {
                     property.PropertyInfo.SetValue(settingsObject, ConvertToPropertyType(value, property));
                 }
-                catch (Exception ex) { skip = true; }
+                catch (Exception ex)
+                {
+                    skip = true;
+                    LibraryEvents.OnSuppressedException(this, ex);
+                }
+            }
             else if (!property.Required)
+            {
                 try
-                { 
+                {
                     property.PropertyInfo.SetValue(settingsObject, property.DefaultValue);
                 }
-                catch (Exception ex) { skip = true; }
+                catch (Exception ex)
+                {
+                    skip = true;
+                    LibraryEvents.OnSuppressedException(this, ex);
+                }
+            }
             else
+            {
                 throw new ArgumentException("Unable to parse required connection string parameter because it does not exist in the connection string.", property.Names.First());
+            }
 
             if (property.ValidationAttributes is null || skip)
                 continue;
 
-            object propertyValue = property.PropertyInfo.GetValue(settingsObject);
+            object? propertyValue = property.PropertyInfo.GetValue(settingsObject);
             string propertyName = key ?? property.Names.First();
 
             foreach (ValidationAttribute attr in property.ValidationAttributes)

--- a/src/Gemstone.Configuration/ConnectionStringParser.cs
+++ b/src/Gemstone.Configuration/ConnectionStringParser.cs
@@ -23,6 +23,7 @@
 //
 //******************************************************************************************************
 // ReSharper disable StaticMemberInGenericType
+// ReSharper disable ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
 
 using System;
 using System.Collections.Concurrent;
@@ -76,7 +77,7 @@ public class ConnectionStringParser
         /// The default value of the property if its value
         /// is not explicitly specified in the connection string.
         /// </summary>
-        public object DefaultValue;
+        public object? DefaultValue;
 
         /// <summary>
         /// Indicates whether or not the property is required
@@ -112,7 +113,7 @@ public class ConnectionStringParser
 
             if (Required)
             {
-                DefaultValue = default!;
+                DefaultValue = null!;
             }
             else
             {
@@ -142,15 +143,12 @@ public class ConnectionStringParser
                 Type? converterType = Type.GetType(typeConverterAttribute.ConverterTypeName);
 
                 if (converterType is not null)
-                    Converter = (TypeConverter)Activator.CreateInstance(converterType);
+                    Converter = (TypeConverter)Activator.CreateInstance(converterType)!;
             }
 
-            //If property is hidden from UI, no longer required
-            if (
-                propertyInfo.TryGetAttribute(out EditorBrowsableAttribute? editorBrowsableAttribute) &&
-                editorBrowsableAttribute is not null &&
-                editorBrowsableAttribute.State == EditorBrowsableState.Never
-                )
+            // If property is hidden from UI, no longer required
+            if (propertyInfo.TryGetAttribute(out EditorBrowsableAttribute? editorBrowsableAttribute) &&
+                editorBrowsableAttribute?.State == EditorBrowsableState.Never)
             {
                 Required = false;
             }
@@ -275,7 +273,7 @@ public class ConnectionStringParser
         Dictionary<string, string> settings = connectionStringProperties
             .Select(property => Tuple.Create(property, property.PropertyInfo.GetValue(settingsObject)))
             .Where(tuple => tuple.Item2 is not null && (ExplicitlySpecifyDefaults || !tuple.Item2.Equals(tuple.Item1.DefaultValue)))
-            .ToDictionary(tuple => tuple.Item1.Names.First(), tuple => ConvertToString(tuple.Item2, tuple.Item1), StringComparer.CurrentCultureIgnoreCase);
+            .ToDictionary(tuple => tuple.Item1.Names.First(), tuple => ConvertToString(tuple.Item2!, tuple.Item1), StringComparer.CurrentCultureIgnoreCase);
 
         // Convert the dictionary to a connection string and return the result
         return settings.JoinKeyValuePairs(ParameterDelimiter, KeyValueDelimiter, StartValueDelimiter, EndValueDelimiter);
@@ -398,7 +396,7 @@ public class ConnectionStringParser
     private static readonly Func<Type, ConnectionStringProperty[]> s_allPropertiesFactory = t =>
     {
         return t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(property => property.CanRead && property.CanWrite)
+            .Where(property => property is { CanRead: true, CanWrite: true })
             .Where(property => !property.TryGetAttribute(out SerializeSettingAttribute? attribute) || attribute.Serialize)
             .Select(property => new ConnectionStringProperty(property))
             .ToArray();
@@ -407,7 +405,7 @@ public class ConnectionStringParser
     private static readonly Func<Type, ConnectionStringProperty[]> s_explicitPropertiesFactory = t =>
     {
         return t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(property => property.CanRead && property.CanWrite)
+            .Where(property => property is { CanRead: true, CanWrite: true })
             .Where(property => property.TryGetAttribute(out SerializeSettingAttribute? attribute) && attribute.Serialize)
             .Select(property => new ConnectionStringProperty(property))
             .ToArray();
@@ -537,11 +535,20 @@ public class ConnectionStringParser<TParameterAttribute> : ConnectionStringParse
     private static readonly ConcurrentDictionary<Type, ConnectionStringProperty[]> s_connectionStringPropertiesLookup = new();
     private static TypeRegistry? s_typeRegistry;
 
-    private static readonly Func<Type, ConnectionStringProperty[]> s_valueFactory = t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-        .Where(property => property.CanRead && property.CanWrite)
-        .Where(HasParameterAttribute)
-        .Select(property => new ConnectionStringProperty(property, s_typeRegistry))
-        .ToArray();
+    private static readonly Func<Type, ConnectionStringProperty[]> s_valueFactory = t =>
+    {
+        PropertyInfo[] candidates = t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property is { CanRead: true, CanWrite: true })
+            .ToArray();
+
+        foreach (PropertyInfo property in candidates)
+            ValidateIgnoreParameterConsistency(property);
+
+        return candidates
+            .Where(HasParameterAttribute)
+            .Select(property => new ConnectionStringProperty(property, s_typeRegistry))
+            .ToArray();
+    };
 
     // Static Properties
 
@@ -574,6 +581,51 @@ public class ConnectionStringParser<TParameterAttribute> : ConnectionStringParse
             return !ignorable.IgnoreWhenParsing;
 
         return true;
+    }
+
+    // Verifies that a property's IIgnorableParameter.IgnoreWhenParsing value is
+    // consistent with any base class declarations of the same property that also
+    // carry the parameter attribute. Catches the common bug where a derived class
+    // overrides a virtual property, reapplies the parameter attribute, but forgets
+    // to set IgnoreWhenParsing to match the base — silently re-enabling auto-parse
+    // on a property the base intended to handle manually. Runs once per type via
+    // the s_valueFactory cache, so the cost is paid only on first use.
+    private static void ValidateIgnoreParameterConsistency(PropertyInfo property)
+    {
+        if (!property.TryGetAttribute(out TParameterAttribute? derivedAttribute))
+            return;
+
+        if (derivedAttribute is not IIgnorableParameter derivedIgnorable)
+            return;
+
+        Type? baseType = property.DeclaringType?.BaseType;
+        string propertyName = property.Name;
+
+        while (baseType is not null)
+        {
+            PropertyInfo? baseProperty = baseType.GetProperty(propertyName, 
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+            if (baseProperty is not null)
+            {
+                object[] baseAttrs = baseProperty.GetCustomAttributes(typeof(TParameterAttribute), inherit: false);
+
+                if (baseAttrs.Length > 0 && baseAttrs[0] is IIgnorableParameter baseIgnorable &&
+                    baseIgnorable.IgnoreWhenParsing != derivedIgnorable.IgnoreWhenParsing)
+                {
+                    throw new InvalidOperationException(
+                        $"Inconsistent {nameof(IIgnorableParameter)}.{nameof(IIgnorableParameter.IgnoreWhenParsing)} " +
+                        $"in inheritance hierarchy: property '{property.DeclaringType?.FullName}.{propertyName}' has " +
+                        $"{nameof(IIgnorableParameter.IgnoreWhenParsing)}={derivedIgnorable.IgnoreWhenParsing}, but the " +
+                        $"base declaration in '{baseType.FullName}' has " +
+                        $"{nameof(IIgnorableParameter.IgnoreWhenParsing)}={baseIgnorable.IgnoreWhenParsing}. " +
+                        $"Override must keep {nameof(IIgnorableParameter.IgnoreWhenParsing)} consistent with the base.");
+                }
+            }
+
+            // 'System.Object.BaseType' returns null which will terminate hierarchy validation
+            baseType = baseType.BaseType;
+        }
     }
 }
 
@@ -609,7 +661,7 @@ public class ConnectionStringParser<TParameterAttribute, TNestedSettingsAttribut
 
         foreach (PropertyInfo property in GetNestedSettingsProperties(settingsObject))
         {
-            object nestedSettingsObject = property.GetValue(settingsObject);
+            object? nestedSettingsObject = property.GetValue(settingsObject);
 
             if (nestedSettingsObject is not null)
                 builder.Append($"; {GetNames(property).First()}={{ {ComposeConnectionString(nestedSettingsObject)} }}");
@@ -627,14 +679,14 @@ public class ConnectionStringParser<TParameterAttribute, TNestedSettingsAttribut
     /// <exception cref="ArgumentException">A required connection string parameter cannot be found in the connection string.</exception>
     public override void ParseConnectionString(string connectionString, object settingsObject)
     {
-        string nestedSettings;
+        string? nestedSettings;
 
         base.ParseConnectionString(connectionString, settingsObject);
         Dictionary<string, string> settings = connectionString.ParseKeyValuePairs();
 
         foreach (PropertyInfo property in GetNestedSettingsProperties(settingsObject))
         {
-            object nestedSettingsObject = property.GetValue(settingsObject);
+            object? nestedSettingsObject = property.GetValue(settingsObject);
             nestedSettings = string.Empty;
 
             if (nestedSettingsObject is null)

--- a/src/Gemstone.Configuration/ConnectionStringParser.cs
+++ b/src/Gemstone.Configuration/ConnectionStringParser.cs
@@ -318,9 +318,9 @@ public class ConnectionStringParser
 
             if (key is not null)
             {
-                // JRC: Manually ignoring 'InputMeasurementKeys' and 'OutputMeasurements' properties for now since
-                // these are currently cannot be handled through `ConvertToPropertyType` method and will simply throw
-                // and exception, be caught and set to skip. This try/catch in combination with reflection is very
+                // JRC: Manually ignoring "InputMeasurementKeys" and "OutputMeasurements" properties for now since
+                // these currently cannot be handled through `ConvertToPropertyType` method and will simply throw
+                // an exception, be caught and set to skip. This try/catch in combination with reflection is very
                 // expensive in adapter load chain where many thousands of adapters will all have these properties:
                 if (key.Equals("InputMeasurementKeys", StringComparison.OrdinalIgnoreCase) || key.Equals("OutputMeasurements", StringComparison.OrdinalIgnoreCase))
                     continue;

--- a/src/Gemstone.Configuration/ConnectionStringParser.cs
+++ b/src/Gemstone.Configuration/ConnectionStringParser.cs
@@ -37,7 +37,6 @@ using Gemstone.Expressions.Evaluator;
 using Gemstone.Expressions.Model;
 using Gemstone.Reflection.MemberInfoExtensions;
 using Gemstone.StringExtensions;
-using Microsoft.Extensions.Logging;
 
 namespace Gemstone.Configuration;
 

--- a/src/UnitTests/Tests.cs
+++ b/src/UnitTests/Tests.cs
@@ -21,6 +21,7 @@
 //
 //******************************************************************************************************
 
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Gemstone.Configuration.UnitTests
@@ -34,4 +35,113 @@ namespace Gemstone.Configuration.UnitTests
             Assert.IsTrue(true);
         }
     }
+
+    #region [ IIgnorableParameter Hierarchy Validation Tests ]
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    internal sealed class TestParameterAttribute : Attribute, ConnectionStringParser<TestParameterAttribute>.IIgnorableParameter
+    {
+        public bool IgnoreWhenParsing { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    internal sealed class PlainParameterAttribute : Attribute
+    {
+    }
+
+    internal class BaseSettings
+    {
+        [TestParameter(IgnoreWhenParsing = true)]
+        public virtual string ManuallyHandled { get; set; } = string.Empty;
+
+        [TestParameter]
+        public virtual string AutoParsed { get; set; } = string.Empty;
+    }
+
+    // BUG case: override re-applies attribute but forgets IgnoreWhenParsing = true.
+    internal class BuggyDerivedSettings : BaseSettings
+    {
+        [TestParameter]
+        public override string ManuallyHandled { get; set; } = string.Empty;
+    }
+
+    // GOOD case: override re-applies attribute and keeps IgnoreWhenParsing = true.
+    internal class GoodDerivedSettings : BaseSettings
+    {
+        [TestParameter(IgnoreWhenParsing = true)]
+        public override string ManuallyHandled { get; set; } = string.Empty;
+    }
+
+    // GOOD case: override does not re-apply attribute; inherited attribute is used.
+    internal class InheritingDerivedSettings : BaseSettings
+    {
+        public override string ManuallyHandled { get; set; } = string.Empty;
+    }
+
+    // Attribute without IIgnorableParameter — validation should be a no-op.
+    internal class PlainBaseSettings
+    {
+        [PlainParameter]
+        public virtual string Value { get; set; } = string.Empty;
+    }
+
+    internal class PlainDerivedSettings : PlainBaseSettings
+    {
+        [PlainParameter]
+        public override string Value { get; set; } = string.Empty;
+    }
+
+    [TestClass]
+    public class IgnorableParameterHierarchyTests
+    {
+        [TestMethod]
+        public void DerivedThatForgetsIgnoreFlag_Throws()
+        {
+            ConnectionStringParser<TestParameterAttribute> parser = new();
+
+            InvalidOperationException ex = Assert.ThrowsException<InvalidOperationException>(
+                () => parser.ParseConnectionString("ManuallyHandled=x;AutoParsed=y", new BuggyDerivedSettings()));
+
+            StringAssert.Contains(ex.Message, nameof(BuggyDerivedSettings));
+            StringAssert.Contains(ex.Message, nameof(BaseSettings));
+            StringAssert.Contains(ex.Message, nameof(TestParameterAttribute.IgnoreWhenParsing));
+        }
+
+        [TestMethod]
+        public void DerivedThatKeepsIgnoreFlag_Succeeds()
+        {
+            ConnectionStringParser<TestParameterAttribute> parser = new();
+            GoodDerivedSettings settings = new();
+
+            parser.ParseConnectionString("AutoParsed=y", settings);
+
+            Assert.AreEqual("y", settings.AutoParsed);
+            Assert.AreEqual(string.Empty, settings.ManuallyHandled);
+        }
+
+        [TestMethod]
+        public void DerivedThatInheritsAttribute_Succeeds()
+        {
+            ConnectionStringParser<TestParameterAttribute> parser = new();
+            InheritingDerivedSettings settings = new();
+
+            parser.ParseConnectionString("AutoParsed=y", settings);
+
+            Assert.AreEqual("y", settings.AutoParsed);
+            Assert.AreEqual(string.Empty, settings.ManuallyHandled);
+        }
+
+        [TestMethod]
+        public void AttributeWithoutIgnorableInterface_NoValidation()
+        {
+            ConnectionStringParser<PlainParameterAttribute> parser = new();
+            PlainDerivedSettings settings = new();
+
+            parser.ParseConnectionString("Value=z", settings);
+
+            Assert.AreEqual("z", settings.Value);
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Verifies that a property's `IIgnorableParameter.IgnoreWhenParsing` value is consistent with any base class declarations of the same property that also carry the parameter attribute. Catches the common bug where a derived class overrides a virtual property, reapplies the parameter attribute, but forgets to set `IgnoreWhenParsing` to match the base — silently re-enabling auto-parse on a property the base intended to handle manually. Runs once per type via the `s_valueFactory` static cache, so the hierarchy traversal cost is paid only on first use.